### PR TITLE
[Update Rails to 5.x] Let rack 2.x

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'jwt', ['>= 1.0', '< 3.0']
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'
-  spec.add_dependency 'rack', '~> 1.2'
+  spec.add_dependency 'rack', '~> 2.0.1'
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.authors       = ['Michael Bleigh', 'Erik Michaels-Ober']
   spec.description   = 'A Ruby wrapper for the OAuth 2.0 protocol built with a similar style to the original OAuth spec.'


### PR DESCRIPTION
`rack` needs to be >= 2.x to update rails to 5.x